### PR TITLE
Implement chunking for OpenAI patch reviews

### DIFF
--- a/src/services/openai.service.ts
+++ b/src/services/openai.service.ts
@@ -1,12 +1,36 @@
 import OpenAI from 'openai';
 
+const MAX_PATCH_CHARS = 10000;
+
 export class OpenAIService {
   private client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY as string });
 
   async reviewPatches(
     patches: Array<{ path: string; line: number; content: string }>,
   ): Promise<Array<{ path: string; line: number; message: string }>> {
-    const prompt = `You are a senior software engineer with extensive experience in code review and security analysis. Your task is to review code changes and provide detailed feedback.
+    const chunks: Array<Array<{ path: string; line: number; content: string }>> = [];
+    let current: Array<{ path: string; line: number; content: string }> = [];
+    let length = 0;
+
+    for (const p of patches) {
+      const str = JSON.stringify(p);
+
+      if (length + str.length > MAX_PATCH_CHARS && current.length) {
+        chunks.push(current);
+        current = [p];
+        length = str.length;
+      } else {
+        current.push(p);
+        length += str.length;
+      }
+    }
+
+    if (current.length) chunks.push(current);
+
+    const allReviews: Array<{ path: string; line: number; message: string }> = [];
+
+    for (const chunk of chunks) {
+      const prompt = `You are a senior software engineer with extensive experience in code review and security analysis. Your task is to review code changes and provide detailed feedback.
 
 System Instructions:
 - Return a JSON object with a single key "reviews" containing an array of review objects
@@ -38,27 +62,30 @@ Review Guidelines:
 4. Prioritize critical issues over style suggestions
 
 Code changes to review:
-${JSON.stringify(patches, null, 2)}`;
+${JSON.stringify(chunk, null, 2)}`;
 
-    const resp = await this.client.chat.completions.create({
-      model: 'gpt-4o-mini',
-      messages: [{ role: 'user', content: prompt }],
-      temperature: 0,
-      response_format: { type: 'json_object' },
-    });
+      const resp = await this.client.chat.completions.create({
+        model: 'gpt-4o-mini',
+        messages: [{ role: 'user', content: prompt }],
+        temperature: 0,
+        response_format: { type: 'json_object' },
+      });
 
-    try {
-      const content = resp.choices[0].message.content;
+      try {
+        const content = resp.choices[0].message.content;
 
-      if (!content) return [];
+        if (!content) continue;
 
-      const parsed = JSON.parse(content);
+        const parsed = JSON.parse(content);
 
-      return parsed.reviews || [];
-    } catch (error: any) {
-      console.error('[OpenAI] Failed to parse review response:', error.message);
+        allReviews.push(...(parsed.reviews || []));
+      } catch (error: any) {
+        console.error('[OpenAI] Failed to parse review response:', error.message);
 
-      return [];
+        continue;
+      }
     }
+
+    return allReviews;
   }
 }


### PR DESCRIPTION
## Summary
- avoid sending overly large prompts to OpenAI by splitting patches into chunks

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68483f0f84e8832381f85aad1abc012b